### PR TITLE
feat #12: 카테고리 리스트 응답 /api/categories 구현

### DIFF
--- a/src/main/java/com/example/expenseadvisor/category/controller/CategoryController.java
+++ b/src/main/java/com/example/expenseadvisor/category/controller/CategoryController.java
@@ -1,0 +1,25 @@
+package com.example.expenseadvisor.category.controller;
+
+import com.example.expenseadvisor.category.dto.CategoryDto;
+import com.example.expenseadvisor.category.dto.CategoryListGetResponse;
+import com.example.expenseadvisor.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping("/api/categories")
+    public ResponseEntity<CategoryListGetResponse> getCategoryList() {
+        List<CategoryDto> categories = categoryService.getCategoryList();
+        return ResponseEntity.ok(new CategoryListGetResponse(categories));
+    }
+
+}

--- a/src/main/java/com/example/expenseadvisor/category/domain/Category.java
+++ b/src/main/java/com/example/expenseadvisor/category/domain/Category.java
@@ -1,0 +1,19 @@
+package com.example.expenseadvisor.category.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+}

--- a/src/main/java/com/example/expenseadvisor/category/dto/CategoryDto.java
+++ b/src/main/java/com/example/expenseadvisor/category/dto/CategoryDto.java
@@ -1,0 +1,21 @@
+package com.example.expenseadvisor.category.dto;
+
+import com.example.expenseadvisor.category.domain.Category;
+import lombok.Getter;
+
+@Getter
+public class CategoryDto {
+
+    private final Long id;
+    private final String name;
+
+    public CategoryDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static CategoryDto from(Category category) {
+        return new CategoryDto(category.getId(), category.getName());
+    }
+
+}

--- a/src/main/java/com/example/expenseadvisor/category/dto/CategoryListGetResponse.java
+++ b/src/main/java/com/example/expenseadvisor/category/dto/CategoryListGetResponse.java
@@ -1,0 +1,16 @@
+package com.example.expenseadvisor.category.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CategoryListGetResponse {
+
+    private final List<CategoryDto> categories;
+
+    public CategoryListGetResponse(List<CategoryDto> categories) {
+        this.categories = categories;
+    }
+
+}

--- a/src/main/java/com/example/expenseadvisor/category/repository/CategoryRepository.java
+++ b/src/main/java/com/example/expenseadvisor/category/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.expenseadvisor.category.repository;
+
+import com.example.expenseadvisor.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/example/expenseadvisor/category/service/CategoryService.java
+++ b/src/main/java/com/example/expenseadvisor/category/service/CategoryService.java
@@ -1,0 +1,23 @@
+package com.example.expenseadvisor.category.service;
+
+import com.example.expenseadvisor.category.dto.CategoryDto;
+import com.example.expenseadvisor.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public List<CategoryDto> getCategoryList() {
+        return categoryRepository.findAll().stream()
+                .map(CategoryDto::from).toList();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,11 @@
 jwt:
   secret: f5aa60c2612f9436772eb65d69a0c117dace6522a5363fe2891c290be99b857c75f86b1b418e5952dd4c9c13f37a709aaea42fe95d5e512960fa3fdf76abfa4d # 테스트 용 시크릿
   token-validity-in-seconds: 300 # 5분
+
+spring:
+  jpa:
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:db/category.sql

--- a/src/main/resources/db/category.sql
+++ b/src/main/resources/db/category.sql
@@ -1,0 +1,4 @@
+INSERT INTO category (id, name)
+values (1, '교통'),
+       (2, '식비')
+;

--- a/src/test/java/com/example/expenseadvisor/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/example/expenseadvisor/category/controller/CategoryControllerTest.java
@@ -1,0 +1,36 @@
+package com.example.expenseadvisor.category.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class CategoryControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @DisplayName("카테고리 목록을 응답해준다.")
+    @WithMockUser()
+    @Test
+    void categoryList() throws Exception {
+        // when, then
+        mockMvc.perform(get("/api/categories"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.categories").isArray());
+    }
+
+}


### PR DESCRIPTION
## 📃 설명

- resolves #12 
- /api/categories, GET

## 🔨 작업 내용

1. sql 파일과 sql.init 기능을 이용하여 category 데이터 적재
2. Controller, Service, Repository 등을 이용한 category 데이터 응답 기능 구현
3. 테스트 추가

## 💬 기타 사항

- 