### PR TITLE
feat/#16 jwt filter for token to authenticaiton

### DIFF
--- a/http/calls.http
+++ b/http/calls.http
@@ -19,3 +19,7 @@ Content-Type: application/json
 > {%
     client.global.set("auth_token", response.body.token);
 %}
+
+### 카테고리 목록
+GET http://localhost:8080/api/categories
+Authorization: Bearer {{auth_token}}

--- a/src/main/java/com/example/expenseadvisor/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/example/expenseadvisor/auth/jwt/JwtFilter.java
@@ -1,0 +1,73 @@
+package com.example.expenseadvisor.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+/**
+ * 사용자의 요청으로부터 JWT를 검사하여 그에 상응하는 Authentication 객체를 SecurityContextFilter에 세팅하는 필터
+ * TODO: GenericFilterBean vs OncePerRequest 스터디 후 둘 중 적합한 것으로 바꾸기
+ */
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class JwtFilter extends GenericFilterBean {
+
+    private final JwtProvider jwtProvider;
+
+    /**
+     * JWT로부터 Authentication 정보를 만들고 SecurityContextHolder에 저장한다.
+     * JWT가 존재하지 않거나 유효한 JWT가 아니라면 아무것도 하지않고 다음 필터를 실행시킨다.
+     *
+     * @param request  The request to process
+     * @param response The response associated with the request
+     * @param chain    Provides access to the next filter in the chain for this filter to pass the request and response
+     *                 to for further processing
+     * @throws IOException
+     * @throws ServletException
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String requestURI = httpServletRequest.getRequestURI();
+        String jwt = resolveToken(httpServletRequest);
+
+        Authentication authentication = jwtProvider.createAuthentication(jwt);
+        if (authentication != null) {
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * HttpservletRequest로부터 JWT를 추출하여 리턴한다.
+     *
+     * @param request HttpServletRequest
+     * @return JWT, 또는 JWT가 유효한 존재하지 않는다면 null
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String BEARER_PREFIX = "Bearer" + " ";
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/example/expenseadvisor/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/example/expenseadvisor/auth/jwt/JwtProvider.java
@@ -13,14 +13,14 @@ import java.util.Date;
 import java.util.stream.Collectors;
 
 @Component
-public class JwtTokenProvider {
+public class JwtProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
     private static final String AUTHORITIES_DELIMITER = ",";
     private final long tokenValidityInMilliSeconds;
     private final SecretKey secretKey;
 
-    public JwtTokenProvider(
+    public JwtProvider(
             @Value("${jwt.secret}") String secret,
             @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds) {
         this.tokenValidityInMilliSeconds = tokenValidityInSeconds * 1000;

--- a/src/main/java/com/example/expenseadvisor/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/example/expenseadvisor/auth/jwt/JwtProvider.java
@@ -1,17 +1,28 @@
 package com.example.expenseadvisor.auth.jwt;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Component
 public class JwtProvider {
 
@@ -29,7 +40,7 @@ public class JwtProvider {
     }
 
     /**
-     * Authentication으로부터 JWT 토큰을 생성하고 리턴
+     * 인증된 Authentication으로부터 JWT 토큰을 생성하고 리턴
      *
      * @param authentication JWT 토큰을 발생하고 싶은 대상 인증 객체
      * @return JWT
@@ -48,6 +59,48 @@ public class JwtProvider {
                 .signWith(secretKey)
                 .expiration(expiration)
                 .compact();
+    }
+
+
+    /**
+     * JWT로부터 parsed된 Claim 리턴
+     *
+     * @param jwt JWT
+     * @return 유효한 JWT라면 parsed된 Claim, 유효하지 않는 JWT라면 null 리턴
+     */
+    private Jws<Claims> getClaims(String jwt) {
+        try {
+            return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(jwt);
+        } catch (UnsupportedJwtException exception) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (JwtException exception) {
+            log.info("잘못된 JWT 토큰입니다.");
+        } catch (IllegalArgumentException exception) {
+            log.info("JWT 토큰이 존재하지 않습니다.");
+        }
+        return null;
+    }
+
+    /**
+     * JWT로부터 Authentication 생성하고 리턴
+     *
+     * @param jwt JWT
+     * @return 유효한 JWT라면 Authentication, 유효한 JWT가 아니라면 null 리턴
+     */
+    public Authentication createAuthentication(String jwt) {
+        Jws<Claims> claims = getClaims(jwt);
+        if (claims == null) {
+            return null;
+        }
+
+        Claims payload = claims.getPayload();
+
+        List<SimpleGrantedAuthority> authorities = Arrays.stream(payload.get(AUTHORITIES_KEY).toString().split(AUTHORITIES_DELIMITER))
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+
+        User principal = new User(payload.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, jwt, authorities);
     }
 
 }

--- a/src/main/java/com/example/expenseadvisor/auth/service/AuthService.java
+++ b/src/main/java/com/example/expenseadvisor/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.example.expenseadvisor.auth.service;
 
 import com.example.expenseadvisor.auth.dto.LoginRequest;
-import com.example.expenseadvisor.auth.jwt.JwtTokenProvider;
+import com.example.expenseadvisor.auth.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtProvider;
 
     public String login(LoginRequest loginRequest) {
         UsernamePasswordAuthenticationToken notAuthenticated = new UsernamePasswordAuthenticationToken(
@@ -25,7 +25,7 @@ public class AuthService {
         // AuthenticationManager를 사용하기 위해서는 UserDetailsService, PasswordEncoder Bean으로 노출할 필요가 있다.
         Authentication authenticated = authenticationManagerBuilder.getObject().authenticate(notAuthenticated);
 
-        return jwtTokenProvider.createToken(authenticated);
+        return jwtProvider.createToken(authenticated);
     }
 
 }

--- a/src/main/java/com/example/expenseadvisor/config/SecurityConfig.java
+++ b/src/main/java/com/example/expenseadvisor/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.expenseadvisor.config;
 
+import com.example.expenseadvisor.auth.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -9,20 +11,31 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.ExceptionTranslationFilter;
 
-@Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
+@Configuration
 public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(customizer -> customizer
-                        .requestMatchers(HttpMethod.POST, "/api/members").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/members").permitAll()       // 회원 가입 엔드포인트 개방
+                        .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()    // 로그인 엔드포인트 개방
                         .anyRequest().authenticated()
                 )
-                .csrf(AbstractHttpConfigurer::disable);
+                .csrf(AbstractHttpConfigurer::disable)
+                // https://stackoverflow.com/questions/59302026/spring-security-why-adding-the-jwt-filter-before-usernamepasswordauthentication
+                // 다음과 같은 순서로 JwtFilter가 놓여진다.
+                // ExceptionTranslationFilter - JwtFilter - AuthorizationFilter(이전에는 FilterSecurityInterceptor. 지금은 Deprecated 되었다.)
+                // 이렇게 함으로써 JwtFilter에서 던지는 예외가 ExceptionTranslationFilter AuthenticationException, AccessDeniedException에 걸리도록 하고
+                // AuthenticationException은 (Custom)AuthenticationEntryPoint에서 핸들하도록 하고
+                // AccessDeniedException은 (Custom)AccessDeniedHandler에서 핸들되도록 하면 된다.
+                .addFilterAfter(jwtFilter, ExceptionTranslationFilter.class);
 
         return http.build();
     }

--- a/src/test/java/com/example/expenseadvisor/auth/jwt/JwtFilterTest.java
+++ b/src/test/java/com/example/expenseadvisor/auth/jwt/JwtFilterTest.java
@@ -1,0 +1,98 @@
+package com.example.expenseadvisor.auth.jwt;
+
+import com.example.expenseadvisor.auth.dto.LoginRequest;
+import com.example.expenseadvisor.auth.service.AuthService;
+import com.example.expenseadvisor.member.dto.MemberCreateRequest;
+import com.example.expenseadvisor.member.repository.MemberRepository;
+import com.example.expenseadvisor.member.service.MemberService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class JwtFilterTest {
+
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    JwtProvider jwtProvider;
+    @Autowired
+    AuthService authService;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberRepository memberRepository;
+
+    String BEARER_PREFIX = "Bearer ";
+    // authenticated를 요청하는 api 엔드포인트로의 호출
+    MockHttpServletRequestBuilder requestBuilder = get("/api/categories").accept(MediaType.APPLICATION_JSON);
+    String testEmail = "test@gmail.com";
+    String testPassword = "12345";
+
+    @BeforeEach
+    void beforeEach() {
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                .email(testEmail)
+                .password(testPassword)
+                .build();
+        memberService.createMember(memberCreateRequest);
+    }
+
+    @AfterEach
+    void afterEach() {
+        memberRepository.deleteAll();
+    }
+
+    @DisplayName("올바른 JWT를 가지고 있는 요청은 authenticated를 요구하는 엔드포인트로 접근할 수 있다.")
+    @Test
+    void givenJWT_thenAccessSucceed() throws Exception {
+        // given - 올바른 JWT 발급
+        LoginRequest loginRequest = new LoginRequest(testEmail, testPassword);
+        String jwt = authService.login(loginRequest);
+
+        // when, then - 올바른 JWT를 이용하여 authenticated를 요구하는 엔드포인트로 접근할 수 있다.
+        mockMvc.perform(requestBuilder.header(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + jwt))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("유효하지 않은 JWT를 가진 요청은 authenticated를 요구하는 엔드포인트로 접근할 수 없다.")
+    @Test
+    void givenNotValidJWT_thenAccessFail() throws Exception {
+        // given - 유효하지 않은 JWT
+        String jwt = "invalid_jwt";
+
+        // when, then - 올바른 JWT를 이용하여 authenticated를 요구하는 엔드포인트로 접근할 수 있다.
+        mockMvc.perform(requestBuilder.header(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + jwt))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("JWT를 가지고 있지 않은 요청은 authenticated를 요구하는 엔드포인트로 접근할 수 없다.")
+    @Test
+    void givenNoJWT_thenAccessFail() throws Exception {
+        // when, then - Authorizaion 헤더 없이 요청 시 Forbidden
+        mockMvc.perform(requestBuilder)
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    // TODO: JwtProvider에서 JWT의 유효성에 대한 예외 결과에 따라 세세하게 응답을 다르게 할 건지 결정하고 세세하게 응답을 한다고 결정했다면 그에 대한 테스트도 추가
+
+
+}


### PR DESCRIPTION
## 📃 설명

- resolves #16

## 🔨 작업 내용

1. JwtFilter 구현하여 HttpRequest의 JWT를 그에 상응하는 Authentication으로 만들고 SecurityContextHolder에 저장하도록 함
2. JwtFilter를 ExceptionTranslationFilter 이후, AuthorizationFilter 이전에 배치하여 JwtFilter에서 추후에 추가될 예외를 ExceptionTranslationFilter에서 처리할 수 있게 함
3. 통합 테스트 추가

## 💬 기타 사항

- 