### PR TITLE
fix #22: 카테고리를 Enum 타입으로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  mysql:
+    image: mysql:latest
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: member
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: expense_advisor
+    ports:
+      - "3309:3306"

--- a/src/main/java/com/example/expenseadvisor/budget/domain/Budget.java
+++ b/src/main/java/com/example/expenseadvisor/budget/domain/Budget.java
@@ -4,6 +4,8 @@ import com.example.expenseadvisor.category.domain.Category;
 import com.example.expenseadvisor.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -17,7 +19,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "category_id"}))
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "category"}))
 @Entity
 public class Budget {
 
@@ -32,8 +34,7 @@ public class Budget {
     @JoinColumn(nullable = false)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(nullable = false)
+    @Enumerated(EnumType.STRING)
     private Category category;
 
     public Budget(int amount, Member member, Category category) {

--- a/src/main/java/com/example/expenseadvisor/budget/dto/BudgetByCategory.java
+++ b/src/main/java/com/example/expenseadvisor/budget/dto/BudgetByCategory.java
@@ -10,13 +10,13 @@ import lombok.NoArgsConstructor;
 public class BudgetByCategory {
 
     @NotNull
-    private Long categoryId;
+    private String category;
 
     @NotNull
     private Integer amount;
 
-    public BudgetByCategory(Long categoryId, Integer amount) {
-        this.categoryId = categoryId;
+    public BudgetByCategory(String category, Integer amount) {
+        this.category = category;
         this.amount = amount;
     }
 

--- a/src/main/java/com/example/expenseadvisor/budget/service/BudgetService.java
+++ b/src/main/java/com/example/expenseadvisor/budget/service/BudgetService.java
@@ -4,7 +4,6 @@ import com.example.expenseadvisor.budget.domain.Budget;
 import com.example.expenseadvisor.budget.dto.BudgetCreateRequest;
 import com.example.expenseadvisor.budget.repository.BudgetRepository;
 import com.example.expenseadvisor.category.domain.Category;
-import com.example.expenseadvisor.category.repository.CategoryRepository;
 import com.example.expenseadvisor.exception.CustomException;
 import com.example.expenseadvisor.exception.ErrorCode;
 import com.example.expenseadvisor.member.domain.Member;
@@ -22,7 +21,6 @@ public class BudgetService {
 
     private final BudgetRepository budgetRepository;
     private final MemberRepository memberRepository;
-    private final CategoryRepository categoryRepository;
 
     @Transactional
     public void createBudgets(BudgetCreateRequest budgetCreateRequest, String email) {
@@ -39,11 +37,7 @@ public class BudgetService {
 
     private List<Budget> toBudgetList(BudgetCreateRequest budgetCreateRequest, Member member) {
         return budgetCreateRequest.getBudgetByCategories().stream()
-                .map(budgetByCategory -> {
-                    Category category = categoryRepository.findById(budgetByCategory.getCategoryId())
-                            .orElseThrow(() -> new CustomException(ErrorCode.CAT_NOT_EXISTS));
-                    return new Budget(budgetByCategory.getAmount(), member, category);
-                })
+                .map(budgetByCategory -> new Budget(budgetByCategory.getAmount(), member, Category.valueOf(budgetByCategory.getCategory())))
                 .toList();
     }
 

--- a/src/main/java/com/example/expenseadvisor/category/domain/Category.java
+++ b/src/main/java/com/example/expenseadvisor/category/domain/Category.java
@@ -1,21 +1,18 @@
 package com.example.expenseadvisor.category.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.Getter;
 
 @Getter
-@Entity
-public class Category {
+public enum Category {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    FOOD("음식"),
+    HOUSING("주거"),
+    HOBBY("취미");
 
-    @Column(nullable = false, unique = true)
-    private String name;
+    private final String viewName;
+
+    Category(String viewName) {
+        this.viewName = viewName;
+    }
 
 }

--- a/src/main/java/com/example/expenseadvisor/category/dto/CategoryDto.java
+++ b/src/main/java/com/example/expenseadvisor/category/dto/CategoryDto.java
@@ -6,16 +6,12 @@ import lombok.Getter;
 @Getter
 public class CategoryDto {
 
-    private final Long id;
     private final String name;
+    private final String viewName;
 
-    public CategoryDto(Long id, String name) {
-        this.id = id;
-        this.name = name;
-    }
-
-    public static CategoryDto from(Category category) {
-        return new CategoryDto(category.getId(), category.getName());
+    public CategoryDto(Category category) {
+        this.name = category.name();
+        this.viewName = category.getViewName();
     }
 
 }

--- a/src/main/java/com/example/expenseadvisor/category/repository/CategoryRepository.java
+++ b/src/main/java/com/example/expenseadvisor/category/repository/CategoryRepository.java
@@ -1,7 +1,0 @@
-package com.example.expenseadvisor.category.repository;
-
-import com.example.expenseadvisor.category.domain.Category;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CategoryRepository extends JpaRepository<Category, Long> {
-}

--- a/src/main/java/com/example/expenseadvisor/category/service/CategoryService.java
+++ b/src/main/java/com/example/expenseadvisor/category/service/CategoryService.java
@@ -1,11 +1,12 @@
 package com.example.expenseadvisor.category.service;
 
+import com.example.expenseadvisor.category.domain.Category;
 import com.example.expenseadvisor.category.dto.CategoryDto;
-import com.example.expenseadvisor.category.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -13,11 +14,8 @@ import java.util.List;
 @Service
 public class CategoryService {
 
-    private final CategoryRepository categoryRepository;
-
     public List<CategoryDto> getCategoryList() {
-        return categoryRepository.findAll().stream()
-                .map(CategoryDto::from).toList();
+        return Arrays.stream(Category.values()).map(CategoryDto::new).toList();
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,13 +3,15 @@ jwt:
   token-validity-in-seconds: 300 # 5분
 
 spring:
+  datasource:
+    url: jdbc:mysql://localhost:3309/expense_advisor?serverTimezone=Asia/Seoul
+    username: member
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
-    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
-  sql:
-    init:
-      mode: always
-      data-locations: classpath:db/category.sql
+        show_sql: true

--- a/src/main/resources/db/category.sql
+++ b/src/main/resources/db/category.sql
@@ -1,5 +1,0 @@
-INSERT INTO category (id, name)
-values (1, '교통'),
-       (2, '식비'),
-       (3, '취미')
-;

--- a/src/test/java/com/example/expenseadvisor/budget/controller/BudgetControllerTest.java
+++ b/src/test/java/com/example/expenseadvisor/budget/controller/BudgetControllerTest.java
@@ -4,7 +4,7 @@ import com.example.expenseadvisor.budget.domain.Budget;
 import com.example.expenseadvisor.budget.dto.BudgetByCategory;
 import com.example.expenseadvisor.budget.dto.BudgetCreateRequest;
 import com.example.expenseadvisor.budget.repository.BudgetRepository;
-import com.example.expenseadvisor.category.repository.CategoryRepository;
+import com.example.expenseadvisor.category.domain.Category;
 import com.example.expenseadvisor.member.domain.Member;
 import com.example.expenseadvisor.member.dto.MemberCreateRequest;
 import com.example.expenseadvisor.member.repository.MemberRepository;
@@ -43,8 +43,6 @@ class BudgetControllerTest {
     @Autowired
     MemberRepository memberRepository;
     @Autowired
-    CategoryRepository categoryRepository;
-    @Autowired
     BudgetRepository budgetRepository;
 
     private final String testEmail = "abc@gmail.com";
@@ -62,7 +60,6 @@ class BudgetControllerTest {
     @AfterEach
     void afterEach() {
         budgetRepository.deleteAll();
-        categoryRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -72,9 +69,9 @@ class BudgetControllerTest {
     void budgetByCategory() throws Exception {
         // given
         List<BudgetByCategory> budgetByCategories = List.of(
-                new BudgetByCategory(1L, 10000),
-                new BudgetByCategory(2L, 20000),
-                new BudgetByCategory(3L, 30000)
+                new BudgetByCategory(Category.FOOD.name(), 10000),
+                new BudgetByCategory(Category.HOUSING.name(), 20000),
+                new BudgetByCategory(Category.HOBBY.name(), 30000)
         );
         BudgetCreateRequest request = new BudgetCreateRequest(budgetByCategories);
 
@@ -89,12 +86,35 @@ class BudgetControllerTest {
         // then
         Member member = memberRepository.findMemberByEmail(testEmail).orElseThrow(() -> new Exception("테스트 멤버가 검색되어야 합니다."));
         List<Budget> all = budgetRepository.findAll();
-        assertThat(all).hasSize(3).extracting("amount", "member.id", "category.id")
+        assertThat(all).hasSize(3).extracting("amount", "member.id", "category")
                 .contains(
-                        Tuple.tuple(10000, member.getId(), 1L),
-                        Tuple.tuple(20000, member.getId(), 2L),
-                        Tuple.tuple(30000, member.getId(), 3L)
+                        Tuple.tuple(10000, member.getId(), Category.FOOD),
+                        Tuple.tuple(20000, member.getId(), Category.HOUSING),
+                        Tuple.tuple(30000, member.getId(), Category.HOBBY)
                 );
     }
+
+//    @DisplayName("예산 설정 요청에는 모든 카테고리에 대한 예산이 들어 있어야 한다. 아니라면 놓친 카테고리에 대한 에러 응답 메시지를 보내야 한다.")
+//    @WithUserDetails(value = testEmail, setupBefore = TestExecutionEvent.TEST_EXECUTION)
+//    @Test
+//    void test() throws Exception {
+//        // given - 카테고리 3번 누락
+//        List<BudgetByCategory> budgetByCategories = List.of(
+//                new BudgetByCategory("FOOD", 10000),
+//                new BudgetByCategory("HOUSING", 20000)
+//                //new BudgetByCategory("HOBBY", 30000)
+//        );
+//        BudgetCreateRequest request = new BudgetCreateRequest(budgetByCategories);
+//
+//        // when
+//        mockMvc.perform(post("/api/budgets")
+//                        .contentType(APPLICATION_JSON)
+//                        .content(objectMapper.writeValueAsString(request))
+//                )
+//                .andDo(print())
+//                .andExpect(status().isBadRequest());
+//
+//        // then
+//    }
 
 }

--- a/src/test/java/com/example/expenseadvisor/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/expenseadvisor/member/controller/MemberControllerTest.java
@@ -4,6 +4,7 @@ import com.example.expenseadvisor.member.domain.Member;
 import com.example.expenseadvisor.member.dto.MemberCreateRequest;
 import com.example.expenseadvisor.member.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,11 @@ class MemberControllerTest {
 
     private final String email = "abc@gmail.com";
     private final String password = "abcd12345";
+
+    @AfterEach
+    void afterEach() {
+        memberRepository.deleteAll();
+    }
 
     @DisplayName("사용자를 생성할 수 있다.")
     @Test

--- a/src/test/java/com/example/expenseadvisor/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/expenseadvisor/member/service/MemberServiceTest.java
@@ -3,6 +3,8 @@ package com.example.expenseadvisor.member.service;
 import com.example.expenseadvisor.member.domain.Member;
 import com.example.expenseadvisor.member.dto.MemberCreateRequest;
 import com.example.expenseadvisor.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +23,16 @@ class MemberServiceTest {
 
     @Autowired
     MemberRepository memberRepository;
+
+    @BeforeEach
+    void beforeEach() {
+
+    }
+
+    @AfterEach
+    void afterEach() {
+        memberRepository.deleteAll();
+    }
 
     @DisplayName("사용자를 생성할 수 있다.")
     @Test


### PR DESCRIPTION
## 📃 설명

- resolves #22
- 카테고리를 Enum 타입으로 관리함으로써 DB 테이블 조회 한단계 감소
  - Enum 타입의 변경이 빈번하지 않음을 가정하고 변경 
  - 추후 다시 테이블로 관리할지도 모르겠으나 지금은 Enum으로 관리

## 🔨 작업 내용

1. Category entity -> Category Enum
2. CategoryRepository 삭제

## 💬 기타 사항

- 